### PR TITLE
Lock protobuf to lower version to fix build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google-cloud-secret-manager==1.0.0
 google-api-core==1.24.0
 oauth2client==4.1.3
 google-api-python-client==1.12.8
+protobuf<3.21.0


### PR DESCRIPTION
fix "TypeError: Descriptors cannot not be created directly."